### PR TITLE
Correctly handle --output_dir argument to run_singularity.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ A prebuilt image is hosted on cloud.sylabs.io: [https://cloud.sylabs.io/library/
 
 ## Installation Instructions
 ### Download AlphaFold and alphafold_singularity:
-N.B. The AlphaFold version and the alphafold_singularity versions must match.
+N.B. The AlphaFold version and the alphafold_singularity versions must match,
+except for the bugfix number in alphafold_singularity. E.g. alphafold_singularity 2.3.2-1
+goes with AlphaFold 2.3.2
 
 ```
-$ export ALPHAFOLD_VERSION=2.3.2
+$ export ALPHAFOLD_VERSION=2.3.2-1
 $ wget https://github.com/deepmind/alphafold/archive/refs/tags/v${ALPHAFOLD_VERSION}.tar.gz -O alphafold-${ALPHAFOLD_VERSION}.tar.gz
 ...
 2023-02-08 17:28:50 (1.24 MB/s) - ‘alphafold-x.x.x.tar.gz’ saved [5855095]

--- a/example_slurm_job.sh
+++ b/example_slurm_job.sh
@@ -3,20 +3,21 @@
 #SBATCH --time=2:00:00
 #SBATCH --gpus=4
 #SBATCH --cpus-per-gpu=12
-#SBATCH --mem=45G
+#SBATCH --mem-per-gpu=36G
 
 ### NOTE
-#### This job script cannot be used without modification for your specific environment.
+### This job script cannot be used without modification for your specific environment.
 
 module load python/gcc/3.11
-module load alphafold/2.3.2
+module load alphafold/2.3.2-1
 
 ### Check values of some environment variables
-echo SLURM_GPUS_ON_NODE=$SLURM_GPUS_ON_NODE
-echo SLURM_JOB_GPUS=$SLURM_JOB_GPUS
-echo SLURM_STEP_GPUS=$SLURM_STEP_GPUS
-echo ALPHAFOLD_DIR=$ALPHAFOLD_DIR
-echo ALPHAFOLD_DATADIR=$ALPHAFOLD_DATADIR
+echo INFO: SLURM_GPUS_ON_NODE=$SLURM_GPUS_ON_NODE
+echo INFO: SLURM_JOB_GPUS=$SLURM_JOB_GPUS
+echo INFO: SLURM_STEP_GPUS=$SLURM_STEP_GPUS
+echo INFO: ALPHAFOLD_DIR=$ALPHAFOLD_DIR
+echo INFO: ALPHAFOLD_DATADIR=$ALPHAFOLD_DATADIR
+echo INFO: TMP=$TMP
 
 ###
 ### README This runs AlphaFold 2.3.2 on the T1050.fasta file
@@ -36,9 +37,17 @@ echo ALPHAFOLD_DATADIR=$ALPHAFOLD_DATADIR
 #
 # On a test system with 4x Tesla V100-SXM2, this took about 6 hours.
 
+# Create output directory in $TMP (which is cleaned up by Slurm at end
+# of job).
+output_dir=$TMP/output
+mkdir -p $output_dir
+
+echo INFO: output_dir=$output_dir
+
 # Run AlphaFold; default is to use GPUs
 python3 ${ALPHAFOLD_DIR}/singularity/run_singularity.py \
     --use_gpu \
+    --output_dir=$output_dir \
     --data_dir=${ALPHAFOLD_DATADIR} \
     --fasta_paths=T1050.fasta \
     --max_template_date=2020-05-14 \
@@ -49,5 +58,5 @@ echo INFO: AlphaFold returned $?
 
 ### Copy Alphafold output back to directory where "sbatch" command was issued.
 mkdir $SLURM_SUBMIT_DIR/Output-$SLURM_JOB_ID
-cp -R $TMPDIR $SLURM_SUBMIT_DIR/Output-$SLURM_JOB_ID
+cp -R $output_dir $SLURM_SUBMIT_DIR/Output-$SLURM_JOB_ID
 


### PR DESCRIPTION
Correctly handle the `--output_dir` argument to the `run_singularity.py` script. Updates to `example_slurm_job.sh` to use the argument. Note on version number in `README.md`.